### PR TITLE
Fix Failed Tests

### DIFF
--- a/Droid/SimpleUITestApp.Droid.csproj
+++ b/Droid/SimpleUITestApp.Droid.csproj
@@ -29,7 +29,7 @@
     <AndroidLinkMode>None</AndroidLinkMode>
     <ConsolePause>false</ConsolePause>
     <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
-    <AndroidSupportedAbis>armeabi-v7a</AndroidSupportedAbis>
+    <AndroidSupportedAbis>armeabi-v7a;armeabi;x86;arm64-v8a;x86_64</AndroidSupportedAbis>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>full</DebugType>

--- a/UITests/Pages/FirstPage.cs
+++ b/UITests/Pages/FirstPage.cs
@@ -30,22 +30,21 @@ namespace SimpleUITestApp.UITests
 			ListViewButtonUsingID = x => x.Marked("MyListViewButton");
 			ActivityIndicatorUsingID = x => x.Marked("MyActivityIndicator");
 
-			//Below shows the improper way to initalize queries
+			//Below shows the improper way to initalize queries.
 			//This code would break if a developer added a third button...
 			//...to the screen and placed it above the "Go Button", because...
-			//...the Go Button would then become Index(1) and the ListViewButton...
-			//...would then become Index(2)
+			//...the Go Button and the ListViewButton Index would change.
 			if (OnAndroid)
 			{
-				GoButton = x => x.Class("Button").Index(0);
+				GoButton = x => x.Class("AppCompatButton").Index(0);
 				EntryField = x => x.Class("EntryEditText");
-				ListViewButton = x => x.Class("Button").Index(1);
+				ListViewButton = x => x.Class("AppCompatButton").Index(1);
 			}
 			if (OniOS)
 			{
-				GoButton = x => x.Class("UIButton").Index(0);
+				GoButton = x => x.Class("UIButton").Index(1);
 				EntryField = x => x.Class("UITextField");
-				ListViewButton = x => x.Class("UIButton").Index(1);
+				ListViewButton = x => x.Class("UIButton").Index(0);
 			}
 		}
 
@@ -55,6 +54,7 @@ namespace SimpleUITestApp.UITests
 			app.ClearText();
 			app.ClearText();
 			app.EnterText(text);
+			app.DismissKeyboard();
 			app.Screenshot($"Enter Text, \"{text}\"");
 		}
 
@@ -64,6 +64,7 @@ namespace SimpleUITestApp.UITests
 			app.ClearText();
 			app.ClearText();
 			app.EnterText(text);
+			app.DismissKeyboard();
 			app.Screenshot($"Enter Text Using IDs, \"{text}\"");
 		}
 

--- a/UITests/Pages/FirstPage.cs
+++ b/UITests/Pages/FirstPage.cs
@@ -1,7 +1,6 @@
 ﻿using Xamarin.UITest;
 
 using Query = System.Func<Xamarin.UITest.Queries.AppQuery, Xamarin.UITest.Queries.AppQuery>;
-using NUnit.Framework;
 
 namespace SimpleUITestApp.UITests
 {
@@ -40,7 +39,7 @@ namespace SimpleUITestApp.UITests
 				EntryField = x => x.Class("EntryEditText");
 				ListViewButton = x => x.Class("AppCompatButton").Index(1);
 			}
-			if (OniOS)
+			else if (OniOS)
 			{
 				GoButton = x => x.Class("UIButton").Index(1);
 				EntryField = x => x.Class("UITextField");
@@ -113,13 +112,19 @@ namespace SimpleUITestApp.UITests
 		public string GetEntryFieldText()
 		{
 			var entryFieldQuery = app.Query(EntryField);
-			return entryFieldQuery[0].Text;
+			return entryFieldQuery[0]?.Text;
 		}
 
 		public string GetEntryFieldTextByID()
 		{
 			var entryFieldQuery = app.Query(EntryFieldUsingID);
-			return entryFieldQuery[0].Text;
+			return entryFieldQuery[0]?.Text;
+		}
+
+		public string GetTitle()
+		{
+			var titleQuery = app.Query("First Page");
+			return titleQuery[0]?.Text;
 		}
 	}
 }

--- a/UITests/Pages/ListViewPage.cs
+++ b/UITests/Pages/ListViewPage.cs
@@ -1,9 +1,12 @@
 ﻿using Xamarin.UITest;
 
+using Query = System.Func<Xamarin.UITest.Queries.AppQuery, Xamarin.UITest.Queries.AppQuery>;
+
 namespace SimpleUITestApp.UITests
 {
 	public class ListViewPage : BasePage
 	{
+
 		public ListViewPage(IApp app, Platform platform) : base(app, platform)
 		{
 		}
@@ -13,7 +16,23 @@ namespace SimpleUITestApp.UITests
 			app.ScrollDownTo(ListItemNumber.ToString());
 			app.Tap(x => x.Marked(ListItemNumber.ToString()));
 			app.WaitForElement("OK");
+		}
+
+		public void TapOKOnAlert()
+		{
+			app.WaitForElement("OK");
 			app.Tap("OK");
+		}
+
+		public string GetAlertText(int numberSelected)
+		{
+			var alertTextQuery = app.Query($"You Selected Number {numberSelected}");
+			return alertTextQuery[0]?.Text;
+		}
+
+		public void TapBackButton()
+		{
+			app.Back();
 		}
 	}
 }

--- a/UITests/Tests/Tests.cs
+++ b/UITests/Tests/Tests.cs
@@ -38,15 +38,25 @@ namespace SimpleUITestApp.UITests
 		[Test]
 		public void SelectItemOnListView()
 		{
+			var listItemNumber = 9;
+			var expectedAlertString = $"You Selected Number {listItemNumber}";
+
 			FirstPage.ClickListViewButton();
-			ListViewPage.TapListItemNumber(9);
+			ListViewPage.TapListItemNumber(listItemNumber);
+
+			Assert.AreEqual(expectedAlertString, ListViewPage.GetAlertText(listItemNumber));
 		}
 
 		[Test]
 		public void SelectItemOnListViewByID()
 		{
+			var listItemNumber = 9;
+			var expectedAlertString = $"You Selected Number {listItemNumber}";
+
 			FirstPage.ClickListViewButtonByID();
-			ListViewPage.TapListItemNumber(9);
+			ListViewPage.TapListItemNumber(listItemNumber);
+
+			Assert.AreEqual(expectedAlertString, ListViewPage.GetAlertText(listItemNumber));
 		}
 
 		[Test]

--- a/iOS/SimpleUITestApp.iOS.csproj
+++ b/iOS/SimpleUITestApp.iOS.csproj
@@ -87,10 +87,6 @@
     <Reference Include="PLCrashReporterUnifiedBinding">
       <HintPath>..\packages\Xamarin.Insights.1.12.3\lib\Xamarin.iOS10\PLCrashReporterUnifiedBinding.dll</HintPath>
     </Reference>
-    <Reference Include="Calabash">
-      <HintPath>..\packages\Xamarin.TestCloud.Agent.0.19.0\lib\Xamarin.iOS10\Calabash.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Xamarin.Forms.Platform.iOS">
       <HintPath>..\packages\Xamarin.Forms.2.2.0.45\lib\Xamarin.iOS10\Xamarin.Forms.Platform.iOS.dll</HintPath>
       <Private>False</Private>
@@ -105,6 +101,10 @@
     </Reference>
     <Reference Include="Xamarin.Forms.Platform">
       <HintPath>..\packages\Xamarin.Forms.2.2.0.45\lib\Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Calabash">
+      <HintPath>..\packages\Xamarin.TestCloud.Agent.0.19.1\lib\Xamarin.iOS10\Calabash.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/iOS/packages.config
+++ b/iOS/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Xamarin.Forms" version="2.2.0.45" targetFramework="xamarinios10" />
   <package id="Xamarin.Insights" version="1.12.3" targetFramework="xamarinios10" />
-  <package id="Xamarin.TestCloud.Agent" version="0.19.0" targetFramework="xamarinios10" />
+  <package id="Xamarin.TestCloud.Agent" version="0.19.1" targetFramework="xamarinios10" />
 </packages>


### PR DESCRIPTION
-Updated Xamarin.TestCloud.Agent to v 0.19.1
-Changed “Button” to “AppCompatButton” on Android First Page UITest
-Changed UIButton Class Indexes for iOS on First Page UITest
-Added DissmissKeyboard to EnterText methods on First Page UITest
-Added Assert to SelectItemOnListView & SelectItemOnListViewByID
-Added methods to ListViewPage UITest
-Added null check for queries in GetEntryFieldTextByID

